### PR TITLE
support more button features 

### DIFF
--- a/src/Bootstrap/Button.elm
+++ b/src/Bootstrap/Button.elm
@@ -5,6 +5,7 @@ module Bootstrap.Button
         , radioButton
         , checkboxButton
         , attrs
+        , onClick
         , small
         , large
         , primary
@@ -34,7 +35,7 @@ You can also group a series of buttons together on a single line with the button
 
 # Button options
 
-@docs attrs, disabled, Option
+@docs attrs, onClick, disabled, Option
 
 ## Roled
 @docs primary, secondary, success, info, warning, danger, roleLink
@@ -160,6 +161,18 @@ checkboxButton checked options children =
 attrs : List (Html.Attribute msg) -> Option msg
 attrs attrs =
     ButtonInternal.Attrs attrs
+
+
+{-| Option to fire a message when the button is clicked
+-}
+onClick : msg -> Option msg
+onClick message =
+    let
+        defaultOptions =
+            Events.defaultOptions
+    in
+        -- prevent default is needed for checkboxButton and radioButton. If False, the click event will fire twice
+        attrs [ Events.onWithOptions "click" { defaultOptions | preventDefault = True } (Decode.succeed message) ]
 
 
 {-| Option to make a button small

--- a/src/Bootstrap/Button.elm
+++ b/src/Bootstrap/Button.elm
@@ -2,6 +2,8 @@ module Bootstrap.Button
     exposing
         ( button
         , linkButton
+        , radioButton
+        , checkboxButton
         , attrs
         , small
         , large
@@ -28,7 +30,7 @@ You can also group a series of buttons together on a single line with the button
 
 
 # Buttons
-@docs button, linkButton
+@docs button, linkButton, radioButton, checkboxButton
 
 # Button options
 
@@ -51,6 +53,8 @@ You can also group a series of buttons together on a single line with the button
 
 import Html
 import Html.Attributes as Attributes exposing (class, classList)
+import Html.Events as Events
+import Json.Decode as Decode
 import Bootstrap.Internal.Button as ButtonInternal
 import Bootstrap.Grid.Internal as GridInternal
 
@@ -100,6 +104,55 @@ linkButton options children =
             :: ButtonInternal.buttonAttributes options
         )
         children
+
+
+{-| Create a radio input that appears as a button
+
+    Button.radioButton True [ Button.primary ] [ text "Primary" ]
+
+
+* `checked` Default value
+* `options` List of styling options
+* `children` List of child elements
+
+-}
+radioButton :
+    Bool
+    -> List (Option msg)
+    -> List (Html.Html msg)
+    -> Html.Html msg
+radioButton checked options children =
+    let
+        hideRadio =
+            -- hides the radio input element, only showing the bootstrap button
+            Attributes.attribute "data-toggle" "button"
+    in
+        Html.label
+            (classList [ ( "active", checked ) ]
+                :: hideRadio
+                :: ButtonInternal.buttonAttributes options
+            )
+            (Html.input [ Attributes.type_ "radio", Attributes.checked checked, Attributes.autocomplete False ] [] :: children)
+
+
+{-| Create a checkbox input that appears as a button
+
+    Button.checkboxButton True [ Button.primary ] [ text "Primary" ]
+
+
+* `checked` Default value
+* `options` List of styling options
+* `children` List of child elements
+
+-}
+checkboxButton :
+    Bool
+    -> List (Option msg)
+    -> List (Html.Html msg)
+    -> Html.Html msg
+checkboxButton checked options children =
+    Html.label (classList [ ( "active", checked ) ] :: ButtonInternal.buttonAttributes options)
+        (Html.input [ Attributes.type_ "checkbox", Attributes.checked checked, Attributes.autocomplete False ] [] :: children)
 
 
 {-| When you need to customize a button element with standard Html.Attribute use this function to create it as a button option

--- a/src/Bootstrap/Button.elm
+++ b/src/Bootstrap/Button.elm
@@ -163,7 +163,7 @@ attrs attrs =
     ButtonInternal.Attrs attrs
 
 
-{-| Option to fire a message when the button is clicked
+{-| Option to fire a message when a button is clicked
 -}
 onClick : msg -> Option msg
 onClick message =

--- a/src/Bootstrap/ButtonGroup.elm
+++ b/src/Bootstrap/ButtonGroup.elm
@@ -4,6 +4,8 @@ module Bootstrap.ButtonGroup
         , groupItem
         , button
         , linkButton
+        , radioButton
+        , checkboxButton
         , toolbar
         , small
         , large
@@ -18,7 +20,7 @@ module Bootstrap.ButtonGroup
 
 # Button group
 
-@docs group, button, linkButton, ButtonItem
+@docs group, button, linkButton, radioButton, checkboxButton, ButtonItem
 
 ## Group options
 @docs small, large, vertical, attrs, Option
@@ -145,6 +147,20 @@ linkButton options children =
     Button.linkButton options children |> ButtonItem
 
 
+{-| Create a radioButton that can be composed in a button group
+-}
+radioButton : Bool -> List (Button.Option msg) -> List (Html.Html msg) -> ButtonItem msg
+radioButton checked options children =
+    Button.radioButton checked options children |> ButtonItem
+
+
+{-| Create a checkboxButton that can be composed in a button group
+-}
+checkboxButton : Bool -> List (Button.Option msg) -> List (Html.Html msg) -> ButtonItem msg
+checkboxButton checked options children =
+    Button.checkboxButton checked options children |> ButtonItem
+
+
 {-| Option to make all buttons in the given group small
 -}
 small : Option msg
@@ -184,6 +200,8 @@ groupAttributes modifiers =
             [ ( "btn-group", True )
             , ( "btn-group-vertical", options.vertical )
             ]
+          -- data-toggle is needed to display radio buttons correctly (by hiding the acutal radio input)
+        , attribute "data-toggle" "buttons"
         ]
             ++ (case (options.size |> Maybe.andThen GridInternal.screenSizeOption) of
                     Just s ->

--- a/src/Bootstrap/ButtonGroup.elm
+++ b/src/Bootstrap/ButtonGroup.elm
@@ -200,7 +200,7 @@ groupAttributes modifiers =
             [ ( "btn-group", True )
             , ( "btn-group-vertical", options.vertical )
             ]
-          -- data-toggle is needed to display radio buttons correctly (by hiding the acutal radio input)
+          -- data-toggle is needed to display radio buttons correctly (by hiding the actual radio input)
         , attribute "data-toggle" "buttons"
         ]
             ++ (case (options.size |> Maybe.andThen GridInternal.screenSizeOption) of

--- a/src/Bootstrap/ButtonGroup.elm
+++ b/src/Bootstrap/ButtonGroup.elm
@@ -1,18 +1,27 @@
 module Bootstrap.ButtonGroup
     exposing
-        ( group
-        , groupItem
+        ( buttonGroup
+        , linkButtonGroup
+        , radioButtonGroup
+        , checkboxButtonGroup
         , button
         , linkButton
         , radioButton
         , checkboxButton
+        , ButtonItem
+        , LinkButtonItem
+        , RadioButtonItem
+        , CheckboxButtonItem
+        , buttonGroupItem
+        , linkButtonGroupItem
+        , radioButtonGroupItem
+        , checkboxButtonGroupItem
         , toolbar
         , small
         , large
         , vertical
         , attrs
         , Option
-        , ButtonItem
         , GroupItem
         )
 
@@ -20,20 +29,24 @@ module Bootstrap.ButtonGroup
 
 # Button group
 
-@docs group, button, linkButton, radioButton, checkboxButton, ButtonItem
+@docs button, linkButton, radioButton, checkboxButton
+@docs buttonGroup, linkButtonGroup, radioButtonGroup, checkboxButtonGroup
+@docs ButtonItem, LinkButtonItem, RadioButtonItem, CheckboxButtonItem
+
 
 ## Group options
 @docs small, large, vertical, attrs, Option
 
 
 # Button toolbar
-@docs toolbar, groupItem, GroupItem
+@docs toolbar, buttonGroupItem, linkButtonGroupItem, radioButtonGroupItem
+@docs checkboxButtonGroupItem, GroupItem
 
 
 -}
 
 import Html
-import Html.Attributes exposing (class, classList, attribute)
+import Html.Attributes as Attributes exposing (class, classList, attribute)
 import Bootstrap.Button as Button
 import Bootstrap.Grid.Internal as GridInternal
 
@@ -59,10 +72,28 @@ type GroupItem msg
     = GroupItem (Html.Html msg)
 
 
-{-| Opaque type representing a button or link button, for composing button groups
+{-| Opaque type representing a button, for composing button groups
 -}
 type ButtonItem msg
     = ButtonItem (Html.Html msg)
+
+
+{-| Opaque type representing a link button, for composing button groups
+-}
+type LinkButtonItem msg
+    = LinkButtonItem (Html.Html msg)
+
+
+{-| Opaque type representing a radio button, for composing button groups
+-}
+type RadioButtonItem msg
+    = RadioButtonItem (Html.Html msg)
+
+
+{-| Opaque type representing a checkbox button, for composing button groups
+-}
+type CheckboxButtonItem msg
+    = CheckboxButtonItem (Html.Html msg)
 
 
 {-| Create a group of related buttons
@@ -77,27 +108,87 @@ type ButtonItem msg
   * `items` List of button items (ref [`buttonItem`](#buttonItem) and [`linkButtonItem`](#linkButtonItem))
 
 -}
-group :
-    List (Option msg)
-    -> List (ButtonItem msg)
-    -> Html.Html msg
-group options items =
-    groupItem options items
+buttonGroup : List (Option msg) -> List (ButtonItem msg) -> Html.Html msg
+buttonGroup options items =
+    buttonGroupItem options items
+        |> renderGroup
+
+
+{-| Create a group of related link buttons. Parameters are identical to [`buttonGroup`](#buttonGroup)
+-}
+linkButtonGroup : List (Option msg) -> List (LinkButtonItem msg) -> Html.Html msg
+linkButtonGroup options items =
+    linkButtonGroupItem options items
+        |> renderGroup
+
+
+{-| Create a group of mutually-exclusive radio buttons. Parameters are identical to [`buttonGroup`](#buttonGroup)
+
+    ButtonGroup.radioButtonGroup
+        [ ButtonGroup.small ]
+        [ ButtonGroup.radioButton True [ Button.primary ] [ text "On" ]
+        , ButtonGroup.radioButton False [ Button.primary ] [ text "Off" ]
+        ]
+-}
+radioButtonGroup : List (Option msg) -> List (RadioButtonItem msg) -> Html.Html msg
+radioButtonGroup options items =
+    radioButtonGroupItem options items
+        |> renderGroup
+
+
+{-| Create a group of related checkbox buttons. Parameters are identical to [`buttonGroup`](#buttonGroup)
+
+    ButtonGroup.checkboxButtonGroup
+        [ ButtonGroup.small ]
+        [ ButtonGroup.checkboxButton True [ Button.primary ] [ text "Bold" ]
+        , ButtonGroup.checkboxButton True [ Button.primary ] [ text "Italic" ]
+        ]
+-}
+checkboxButtonGroup : List (Option msg) -> List (CheckboxButtonItem msg) -> Html.Html msg
+checkboxButtonGroup options items =
+    checkboxButtonGroupItem options items
         |> renderGroup
 
 
 {-| Create a button group that can be composed in a [`toolbar`](#toolbar)
 
-The parameters are identical as for [`group`](#group)
+The parameters are identical as for [`buttonGroup`](#buttonGroup)
 -}
-groupItem :
-    List (Option msg)
-    -> List (ButtonItem msg)
-    -> GroupItem msg
-groupItem options items =
+buttonGroupItem : List (Option msg) -> List (ButtonItem msg) -> GroupItem msg
+buttonGroupItem options items =
     Html.div
         (groupAttributes options)
         (List.map (\(ButtonItem elem) -> elem) items)
+        |> GroupItem
+
+
+{-| The same as [`buttonGroupItem`](#buttonGroupItem), but for link buttons
+-}
+linkButtonGroupItem : List (Option msg) -> List (LinkButtonItem msg) -> GroupItem msg
+linkButtonGroupItem options items =
+    Html.div
+        (groupAttributes options)
+        (List.map (\(LinkButtonItem elem) -> elem) items)
+        |> GroupItem
+
+
+{-| The same as [`buttonGroupItem`](#buttonGroupItem), but for radio buttons
+-}
+radioButtonGroupItem : List (Option msg) -> List (RadioButtonItem msg) -> GroupItem msg
+radioButtonGroupItem options items =
+    Html.div
+        (groupAttributes options)
+        (List.map (\(RadioButtonItem elem) -> elem) items)
+        |> GroupItem
+
+
+{-| The same as [`buttonGroupItem`](#buttonGroupItem), but for checkbox buttons
+-}
+checkboxButtonGroupItem : List (Option msg) -> List (CheckboxButtonItem msg) -> GroupItem msg
+checkboxButtonGroupItem options items =
+    Html.div
+        (groupAttributes options)
+        (List.map (\(CheckboxButtonItem elem) -> elem) items)
         |> GroupItem
 
 
@@ -142,23 +233,23 @@ button options children =
 
 {-| Create a linkButton that can be composed in a button group
 -}
-linkButton : List (Button.Option msg) -> List (Html.Html msg) -> ButtonItem msg
+linkButton : List (Button.Option msg) -> List (Html.Html msg) -> LinkButtonItem msg
 linkButton options children =
-    Button.linkButton options children |> ButtonItem
+    Button.linkButton options children |> LinkButtonItem
 
 
 {-| Create a radioButton that can be composed in a button group
 -}
-radioButton : Bool -> List (Button.Option msg) -> List (Html.Html msg) -> ButtonItem msg
+radioButton : Bool -> List (Button.Option msg) -> List (Html.Html msg) -> RadioButtonItem msg
 radioButton checked options children =
-    Button.radioButton checked options children |> ButtonItem
+    Button.radioButton checked options children |> RadioButtonItem
 
 
 {-| Create a checkboxButton that can be composed in a button group
 -}
-checkboxButton : Bool -> List (Button.Option msg) -> List (Html.Html msg) -> ButtonItem msg
+checkboxButton : Bool -> List (Button.Option msg) -> List (Html.Html msg) -> CheckboxButtonItem msg
 checkboxButton checked options children =
-    Button.checkboxButton checked options children |> ButtonItem
+    Button.checkboxButton checked options children |> CheckboxButtonItem
 
 
 {-| Option to make all buttons in the given group small


### PR DESCRIPTION
This PR adds 

* radio and checkbox elements as buttons (see [the bootstrap docs](https://v4-alpha.getbootstrap.com/components/buttons/#checkbox-and-radio-buttons))
in the Button and ButtonGroup module. 
* `Button.onClick`  for convenience and because radioButton and checkboxButton need preventDefault=True on the "click" event to work properly. 

I've implemented the above features because I needed them. to completely cover the bootstrap buttons we could also add `Button.toggle` which sets `data-toggle="button"`.

