### PR TITLE
Add alignXlLeft, alignXlCenter and alignXlRight to Bootstrap.Text exposing list

### DIFF
--- a/src/Bootstrap/Text.elm
+++ b/src/Bootstrap/Text.elm
@@ -12,13 +12,16 @@ module Bootstrap.Text
         , alignLgLeft
         , alignLgCenter
         , alignLgRight
+        , alignXlLeft
+        , alignXlCenter
+        , alignXlRight
         , HAlign
         )
 
 {-| Utilities for text options. Currently only exposing helpers used by Bootstrap.Card for horizontal alignment
 
 
-@docs alignXsLeft, alignXsCenter, alignXsRight, alignSmLeft, alignSmCenter, alignSmRight, alignMdLeft, alignMdCenter, alignMdRight, alignLgLeft, alignLgCenter, alignLgRight, HAlign
+@docs alignXsLeft, alignXsCenter, alignXsRight, alignSmLeft, alignSmCenter, alignSmRight, alignMdLeft, alignMdCenter, alignMdRight, alignLgLeft, alignLgCenter, alignLgRight, alignXlLeft, alignXlCenter, alignXlRight, HAlign
 
 -}
 


### PR DESCRIPTION
These functions were not exposed and not used within the module, I figured that these had to be exposed just as the other align+size functions.

PS: I didn't format the file with `elm-format`. For future PRs, do you want formatted files using `elm-format`?