### PR TITLE
Fix typo in docs

### DIFF
--- a/src/Bootstrap/CDN.elm
+++ b/src/Bootstrap/CDN.elm
@@ -2,7 +2,7 @@ module Bootstrap.CDN exposing (stylesheet, fontAwesome)
 
 
 
-{-| Helper module for easily embedding css when you want to work with the library using the Elm Raactor
+{-| Helper module for easily embedding css when you want to work with the library using the Elm Reactor
 
 
 @docs stylesheet, fontAwesome


### PR DESCRIPTION
Thanks for the work on this useful library! Found a little typo browsing the docs...