### PR TITLE
Remove unused CardBlock type

### DIFF
--- a/src/Bootstrap/Card.elm
+++ b/src/Bootstrap/Card.elm
@@ -45,7 +45,6 @@ module Bootstrap.Card
         , Config
         , CardOption
         , BlockOption
-        , CardBlock
         , CardFooter
         , CardHeader
         , CardImageBottom
@@ -78,7 +77,7 @@ You can customize the look and feel of your cards using the following options
 
 
 # Blocks
-@docs block, listGroup, CardBlock, BlockItem
+@docs block, listGroup, BlockItem
 
 
 ## Block title
@@ -112,15 +111,14 @@ import Bootstrap.Internal.Card as CardInternal
 
 {-| Opaque type representing options for customizing the styling of a card
 -}
-type alias CardOption msg = CardInternal.CardOption msg
-
+type alias CardOption msg =
+    CardInternal.CardOption msg
 
 
 {-| Opaque type representing options for styling a card block
 -}
-type alias BlockOption msg = CardInternal.BlockOption msg
-
-
+type alias BlockOption msg =
+    CardInternal.BlockOption msg
 
 
 {-| Opaque type representing the view configuration of a card
@@ -168,17 +166,10 @@ type CardImageBottom msg
     = CardImageBottom (Html.Html msg)
 
 
-{-| Opaque type representing a card block element
--}
-type CardBlock msg
-    = CardBlock (Html.Html msg)
-    | ListGroup (Html.Html msg)
-
-
 {-| Opaque type representing a legal card block child element
 -}
-type alias BlockItem msg = CardInternal.BlockItem msg
-
+type alias BlockItem msg =
+    CardInternal.BlockItem msg
 
 
 
@@ -261,7 +252,9 @@ outlineDanger : CardOption msg
 outlineDanger =
     CardInternal.Coloring <| CardInternal.Outlined CardInternal.Danger
 
-{-| Give cards a custom dark background color with light text -}
+
+{-| Give cards a custom dark background color with light text
+-}
 inverted : Color.Color -> CardOption msg
 inverted color =
     CardInternal.Coloring <| CardInternal.Inverted color
@@ -310,13 +303,13 @@ view :
     -> Html.Html msg
 view (Config { options, header, footer, imgTop, imgBottom, blocks }) =
     Html.div
-        (CardInternal.cardAttributes options )
+        (CardInternal.cardAttributes options)
         (List.filterMap
             identity
             [ Maybe.map (\(CardHeader e) -> e) header
             , Maybe.map (\(CardImageTop e) -> e) imgTop
             ]
-            ++ ( CardInternal.renderBlocks blocks )
+            ++ (CardInternal.renderBlocks blocks)
             ++ List.filterMap
                 identity
                 [ Maybe.map (\(CardFooter e) -> e) footer
@@ -551,7 +544,7 @@ block options items (Config config) =
         { config
             | blocks =
                 config.blocks
-                    ++ [ CardInternal.block options items]
+                    ++ [ CardInternal.block options items ]
         }
 
 
@@ -569,9 +562,6 @@ listGroup items (Config config) =
                 config.blocks
                     ++ [ CardInternal.listGroup items ]
         }
-
-
-
 
 
 {-| Create link elements that are placed next to each other in a block using this function
@@ -600,11 +590,12 @@ text attributes children =
         |> CardInternal.BlockItem
 
 
-{-|  Add a custom HTML element to be displayed in a Card block
+{-| Add a custom HTML element to be displayed in a Card block
 -}
 custom : Html.Html msg -> BlockItem msg
 custom element =
     CardInternal.BlockItem element
+
 
 {-| Create a block quote element
 
@@ -729,5 +720,3 @@ columns cards =
 
 
 -- PRIVATE Helpers etc
-
-


### PR DESCRIPTION
Only the type was exposed, but none of the value constructors were used.
I assume these could be removed.

Note that this will be a major change, which you might not want to merge directly to avoid the major version number going up too fast.