### PR TITLE
Fix custom attributes in InputGroup

### DIFF
--- a/src/Bootstrap/Form/InputGroup.elm
+++ b/src/Bootstrap/Form/InputGroup.elm
@@ -118,6 +118,7 @@ view (Config config) =
                 ++ ([ Maybe.andThen sizeAttribute config.size ]
                         |> List.filterMap identity
                    )
+                ++ config.attributes
             )
             (List.map (\(Addon e) -> e) config.predecessors
                 ++ [ input ]


### PR DESCRIPTION
Appended config.attributes to Html attribute list in InputGroup.view function.
Fixes #40 