### PR TITLE
Add tests for ListGroup

### DIFF
--- a/tests/Bootstrap/ListGroupTest.elm
+++ b/tests/Bootstrap/ListGroupTest.elm
@@ -15,143 +15,134 @@ all : Test
 all =
     Test.concat
         [ vanillaListGroup
-        , keyedListGroup
         , contextualListGroup
         , customListGroup
         , contextualListGroup
         ]
 
 
-vanillaListGroup : Test
 vanillaListGroup =
     let
-        html =
-            ListGroup.ul
-                [ ListGroup.li [] [ text "List item 1" ]
-                ]
+        items =
+            [ ( "basic", ListGroup.li [] [ text "basic" ] )
+            , ( "active", ListGroup.li [ ListGroup.active ] [ text "active" ] )
+            , ( "disabled", ListGroup.li [ ListGroup.disabled ] [ text "disabled" ] )
+            ]
 
-        active =
-            ListGroup.ul
-                [ ListGroup.li [ ListGroup.active ] [ text "List item 1" ]
-                ]
+        vanilla =
+            ListGroup.ul (List.map Tuple.second items)
 
-        disabled =
-            ListGroup.ul
-                [ ListGroup.li [ ListGroup.disabled ] [ text "List item 1" ]
-                ]
-    in
-        describe "vanilla ListGroup"
+        keyed =
+            ListGroup.keyedUl items
+
+        tests html =
             [ test "expect ul with list-group class" <|
                 \() ->
                     html
                         |> Query.fromHtml
                         |> Query.has [ tag "ul", class "list-group" ]
-            , test "expect li with list-group-item class" <|
+            , test "expect three li's with list-group-item class" <|
                 \() ->
                     html
                         |> Query.fromHtml
-                        |> Query.has [ tag "li", class "list-group-item" ]
-            , test "expect li is not disabled" <|
-                \() ->
-                    html
-                        |> Query.fromHtml
-                        |> Query.has [ tag "li", Selector.disabled False ]
+                        |> Query.findAll [ tag "li", class "list-group-item" ]
+                        |> Query.count (Expect.equal 3)
             , test "expect li has content" <|
                 \() ->
                     html
                         |> Query.fromHtml
-                        |> Query.has [ tag "li", Selector.text "List item 1" ]
+                        |> Query.findAll [ tag "li" ]
+                        |> Query.index 0
+                        |> Query.has [ Selector.text "basic" ]
             , test "expect li with active class" <|
                 \() ->
-                    active
+                    html
                         |> Query.fromHtml
-                        |> Query.has [ tag "li", class "active" ]
+                        |> Query.findAll [ tag "li" ]
+                        |> Query.index 1
+                        |> Query.has [ class "active" ]
             , test "expect li with disabled class and attribute" <|
                 \() ->
-                    disabled
+                    html
                         |> Query.fromHtml
-                        |> Query.has [ tag "li", class "disabled", Selector.disabled True ]
+                        |> Query.findAll [ tag "li" ]
+                        |> Query.index 2
+                        |> Query.has [ class "disabled", Selector.disabled True ]
             ]
-
-
-{-| The fact that an element is keyed is not visible from the dom, so
-this just tests that the keyed versions produce the same html as the "vanilla" ones
--}
-keyedListGroup : Test
-keyedListGroup =
-    let
-        keyed =
-            ListGroup.keyedUl
-                [ ( "List item 1", ListGroup.li [] [ text "List item 1" ] )
-                ]
-
-        customKeyed =
-            ListGroup.keyedCustom
-                [ ( "List item 1", ListGroup.button [] [ text "List item 1" ] )
-                ]
     in
-        describe "keyed ListGroup"
-            [ test "expect ul with list-group class" <|
-                \() ->
-                    keyed
-                        |> Query.fromHtml
-                        |> Query.has [ tag "ul", class "list-group" ]
-            , test "expect li with list-group-item class" <|
-                \() ->
-                    keyed
-                        |> Query.fromHtml
-                        |> Query.has [ tag "li", class "list-group-item" ]
-            , test "expect div with list-group class" <|
-                \() ->
-                    customKeyed
-                        |> Query.fromHtml
-                        |> Query.has [ tag "div", class "list-group" ]
-            , test "expect button with list-group-item class" <|
-                \() ->
-                    customKeyed
-                        |> Query.fromHtml
-                        |> Query.has [ tag "button", class "list-group-item", class "list-group-item-action" ]
+        describe "basic ListGroup"
+            [ describe "vanilla ListGroup" (tests vanilla)
+            , describe "keyed ListGroup" (tests keyed)
             ]
 
 
 customListGroup : Test
 customListGroup =
     let
-        anchors =
-            ListGroup.custom
-                [ ListGroup.anchor [ ListGroup.active, ListGroup.attrs [ href "javascript:void();" ] ] [ text "List item 1" ]
-                , ListGroup.anchor [ ListGroup.attrs [ href "javascript:void();" ] ] [ text "List item 2" ]
-                , ListGroup.anchor [ ListGroup.disabled, ListGroup.attrs [ href "http://www.google.com" ] ] [ text "List item 3" ]
-                ]
+        anchorItems =
+            [ ( "item 1", ListGroup.anchor [ ListGroup.attrs [ href "javascript:void();" ] ] [ text "List item 1" ] )
+            , ( "item 2", ListGroup.anchor [ ListGroup.active, ListGroup.attrs [ href "javascript:void();" ] ] [ text "List item 2" ] )
+            , ( "item 3", ListGroup.anchor [ ListGroup.disabled, ListGroup.attrs [ href "http://www.google.com" ] ] [ text "List item 3" ] )
+            ]
 
-        buttons =
-            ListGroup.custom
-                [ ListGroup.button [ ListGroup.active ] [ text "List item 1" ]
-                , ListGroup.button [] [ text "List item 2" ]
-                , ListGroup.button [ ListGroup.disabled ] [ text "List item 3" ]
-                ]
-    in
-        describe "Custom ListGroup"
+        buttonItems =
+            [ ( "item 1", ListGroup.button [] [ text "List item 1" ] )
+            , ( "item 2", ListGroup.button [ ListGroup.active ] [ text "List item 2" ] )
+            , ( "item 3", ListGroup.button [ ListGroup.disabled ] [ text "List item 3" ] )
+            ]
+
+        tests itemTag html =
             [ test "expect div with list-group class" <|
                 \() ->
-                    anchors
+                    html
                         |> Query.fromHtml
                         |> Query.has [ tag "div", class "list-group" ]
-            , test "expect a with list-group-item class" <|
+            , test "expect three items with list-group-item class" <|
                 \() ->
-                    anchors
+                    html
                         |> Query.fromHtml
-                        |> Query.has [ tag "a", class "list-group-item", class "list-group-item-action" ]
-            , test "expect div with list-group class" <|
+                        |> Query.findAll [ tag itemTag, class "list-group-item", class "list-group-item-action" ]
+                        |> Query.count (Expect.equal 3)
+            , test "expect item has content" <|
                 \() ->
-                    buttons
+                    html
                         |> Query.fromHtml
-                        |> Query.has [ tag "div", class "list-group" ]
-            , test "expect button with list-group-item class" <|
+                        |> Query.findAll [ tag itemTag ]
+                        |> Query.index 0
+                        |> Query.has [ Selector.text "List item 1" ]
+            , test "expect item with active class" <|
                 \() ->
-                    buttons
+                    html
                         |> Query.fromHtml
-                        |> Query.has [ tag "button", class "list-group-item", class "list-group-item-action" ]
+                        |> Query.findAll [ tag itemTag ]
+                        |> Query.index 1
+                        |> Query.has [ class "active" ]
+            , test "expect item with disabled class and attribute" <|
+                \() ->
+                    html
+                        |> Query.fromHtml
+                        |> Query.findAll [ tag itemTag ]
+                        |> Query.index 2
+                        |> Query.has [ class "disabled", Selector.disabled True ]
+            ]
+
+        anchors =
+            ListGroup.custom (List.map Tuple.second anchorItems)
+
+        keyedAnchors =
+            ListGroup.keyedCustom anchorItems
+
+        buttons =
+            ListGroup.custom (List.map Tuple.second buttonItems)
+
+        keyedButtons =
+            ListGroup.keyedCustom buttonItems
+    in
+        describe "custom ListGroup"
+            [ describe "anchors" (tests "a" anchors)
+            , describe "keyed anchors" (tests "a" keyedAnchors)
+            , describe "buttons" (tests "button" buttons)
+            , describe "keyed buttons" (tests "button" keyedButtons)
             ]
 
 

--- a/tests/Bootstrap/ListGroupTest.elm
+++ b/tests/Bootstrap/ListGroupTest.elm
@@ -1,0 +1,210 @@
+module Bootstrap.ListGroupTest exposing (..)
+
+import Bootstrap.ListGroup as ListGroup
+import Html exposing (text)
+import Html.Attributes as Attr exposing (href)
+import Test exposing (Test, test, describe)
+import Expect
+import Test.Html.Query as Query
+import Test.Html.Selector as Selector exposing (tag, class, classes, attribute, disabled)
+
+
+{-| @ltignore
+-}
+all : Test
+all =
+    Test.concat
+        [ vanillaListGroup
+        , keyedListGroup
+        , contextualListGroup
+        , customListGroup
+        , contextualListGroup
+        ]
+
+
+vanillaListGroup : Test
+vanillaListGroup =
+    let
+        html =
+            ListGroup.ul
+                [ ListGroup.li [] [ text "List item 1" ]
+                ]
+
+        active =
+            ListGroup.ul
+                [ ListGroup.li [ ListGroup.active ] [ text "List item 1" ]
+                ]
+
+        disabled =
+            ListGroup.ul
+                [ ListGroup.li [ ListGroup.disabled ] [ text "List item 1" ]
+                ]
+    in
+        describe "vanilla ListGroup"
+            [ test "expect ul with list-group class" <|
+                \() ->
+                    html
+                        |> Query.fromHtml
+                        |> Query.has [ tag "ul", class "list-group" ]
+            , test "expect li with list-group-item class" <|
+                \() ->
+                    html
+                        |> Query.fromHtml
+                        |> Query.has [ tag "li", class "list-group-item" ]
+            , test "expect li is not disabled" <|
+                \() ->
+                    html
+                        |> Query.fromHtml
+                        |> Query.has [ tag "li", Selector.disabled False ]
+            , test "expect li has content" <|
+                \() ->
+                    html
+                        |> Query.fromHtml
+                        |> Query.has [ tag "li", Selector.text "List item 1" ]
+            , test "expect li with active class" <|
+                \() ->
+                    active
+                        |> Query.fromHtml
+                        |> Query.has [ tag "li", class "active" ]
+            , test "expect li with disabled class and attribute" <|
+                \() ->
+                    disabled
+                        |> Query.fromHtml
+                        |> Query.has [ tag "li", class "disabled", Selector.disabled True ]
+            ]
+
+
+{-| The fact that an element is keyed is not visible from the dom, so
+this just tests that the keyed versions produce the same html as the "vanilla" ones
+-}
+keyedListGroup : Test
+keyedListGroup =
+    let
+        keyed =
+            ListGroup.keyedUl
+                [ ( "List item 1", ListGroup.li [] [ text "List item 1" ] )
+                ]
+
+        customKeyed =
+            ListGroup.keyedCustom
+                [ ( "List item 1", ListGroup.button [] [ text "List item 1" ] )
+                ]
+    in
+        describe "keyed ListGroup"
+            [ test "expect ul with list-group class" <|
+                \() ->
+                    keyed
+                        |> Query.fromHtml
+                        |> Query.has [ tag "ul", class "list-group" ]
+            , test "expect li with list-group-item class" <|
+                \() ->
+                    keyed
+                        |> Query.fromHtml
+                        |> Query.has [ tag "li", class "list-group-item" ]
+            , test "expect div with list-group class" <|
+                \() ->
+                    customKeyed
+                        |> Query.fromHtml
+                        |> Query.has [ tag "div", class "list-group" ]
+            , test "expect button with list-group-item class" <|
+                \() ->
+                    customKeyed
+                        |> Query.fromHtml
+                        |> Query.has [ tag "button", class "list-group-item", class "list-group-item-action" ]
+            ]
+
+
+customListGroup : Test
+customListGroup =
+    let
+        anchors =
+            ListGroup.custom
+                [ ListGroup.anchor [ ListGroup.active, ListGroup.attrs [ href "javascript:void();" ] ] [ text "List item 1" ]
+                , ListGroup.anchor [ ListGroup.attrs [ href "javascript:void();" ] ] [ text "List item 2" ]
+                , ListGroup.anchor [ ListGroup.disabled, ListGroup.attrs [ href "http://www.google.com" ] ] [ text "List item 3" ]
+                ]
+
+        buttons =
+            ListGroup.custom
+                [ ListGroup.button [ ListGroup.active ] [ text "List item 1" ]
+                , ListGroup.button [] [ text "List item 2" ]
+                , ListGroup.button [ ListGroup.disabled ] [ text "List item 3" ]
+                ]
+    in
+        describe "Custom ListGroup"
+            [ test "expect div with list-group class" <|
+                \() ->
+                    anchors
+                        |> Query.fromHtml
+                        |> Query.has [ tag "div", class "list-group" ]
+            , test "expect a with list-group-item class" <|
+                \() ->
+                    anchors
+                        |> Query.fromHtml
+                        |> Query.has [ tag "a", class "list-group-item", class "list-group-item-action" ]
+            , test "expect div with list-group class" <|
+                \() ->
+                    buttons
+                        |> Query.fromHtml
+                        |> Query.has [ tag "div", class "list-group" ]
+            , test "expect button with list-group-item class" <|
+                \() ->
+                    buttons
+                        |> Query.fromHtml
+                        |> Query.has [ tag "button", class "list-group-item", class "list-group-item-action" ]
+            ]
+
+
+contextual : String -> Html.Html msg -> Test
+contextual name html =
+    describe name
+        [ test "expect success" <|
+            \() ->
+                html
+                    |> Query.fromHtml
+                    |> Query.find [ class "list-group-item-success" ]
+                    |> Query.has [ Selector.text "success" ]
+        , test "expect info" <|
+            \() ->
+                html
+                    |> Query.fromHtml
+                    |> Query.find [ class "list-group-item-info" ]
+                    |> Query.has [ Selector.text "info" ]
+        , test "expect warning" <|
+            \() ->
+                html
+                    |> Query.fromHtml
+                    |> Query.find [ class "list-group-item-warning" ]
+                    |> Query.has [ Selector.text "warning" ]
+        , test "expect danger" <|
+            \() ->
+                html
+                    |> Query.fromHtml
+                    |> Query.find [ class "list-group-item-danger" ]
+                    |> Query.has [ Selector.text "danger" ]
+        ]
+
+
+contextualListGroup : Test
+contextualListGroup =
+    let
+        contextualList =
+            ListGroup.ul
+                [ ListGroup.li [ ListGroup.success ] [ text "success" ]
+                , ListGroup.li [ ListGroup.info ] [ text "info" ]
+                , ListGroup.li [ ListGroup.warning ] [ text "warning" ]
+                , ListGroup.li [ ListGroup.danger ] [ text "danger" ]
+                ]
+
+        contextualButtonList =
+            ListGroup.custom
+                [ ListGroup.button [ ListGroup.success ] [ text "success" ]
+                , ListGroup.button [ ListGroup.info ] [ text "info" ]
+                , ListGroup.button [ ListGroup.warning ] [ text "warning" ]
+                , ListGroup.button [ ListGroup.danger ] [ text "danger" ]
+                ]
+    in
+        describe "contextual ListGroup"
+            [ contextual "ListGroup with contextual items" contextualList
+            , contextual "custom ListGroup with contextual items" contextualButtonList
+            ]

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -5,6 +5,7 @@ import Bootstrap.BadgeTest as BadgeTest
 import Bootstrap.ButtonTest as ButtonTest
 import Bootstrap.CardTest as CardTest
 import Bootstrap.DropdownTest as DropdownTest
+import Bootstrap.ListGroupTest as ListGroupTest
 import Bootstrap.TableTest as TableTest
 import Bootstrap.ProgressTest as ProgressTest
 import Test exposing (..)
@@ -20,6 +21,7 @@ all =
         , ButtonTest.all
         , CardTest.all
         , DropdownTest.all
+        , ListGroupTest.all
         , TableTest.all
         , ProgressTest.all
         ]


### PR DESCRIPTION
would like a quick second pair of eyeballs on this. 

In particular the tests for keyed elements. I've copied tests for the normal elements to check the keyed ones produce the same html. Maybe it would be better to define the tests once as a function taking a `Html msg`, then applying that function to a standard and a keyed piece of html? 
