### PR TITLE
Expose Bootstrap.Form.Fieldset in elm-package.json.

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -17,6 +17,7 @@
         "Bootstrap.Dropdown",
         "Bootstrap.Form",
         "Bootstrap.Form.Checkbox",
+        "Bootstrap.Form.Fieldset",
         "Bootstrap.Form.Input",
         "Bootstrap.Form.InputGroup",
         "Bootstrap.Form.Radio",


### PR DESCRIPTION
Hi. I must warn you that I don't really know Elm properly, but it seems to me that Bootstrap.Form.Fieldset should be among the exposed modules in elm-package.json.