### PR TITLE
Add tests for Tab

### DIFF
--- a/tests/Bootstrap/TabTest.elm
+++ b/tests/Bootstrap/TabTest.elm
@@ -48,7 +48,7 @@ simpleTabs =
         nav =
             html
                 |> Query.fromHtml
-                |> Query.find [ class "nav" ]
+                |> Query.find [ class "nav", class "nav-tabs" ]
 
         content =
             html

--- a/tests/Bootstrap/TabTest.elm
+++ b/tests/Bootstrap/TabTest.elm
@@ -1,0 +1,143 @@
+module Bootstrap.TabTest exposing (..)
+
+import Bootstrap.Tab as Tab
+import Html exposing (text, h4, p)
+import Html.Attributes as Attributes
+import Test exposing (Test, test, describe)
+import Expect
+import Test.Html.Query as Query
+import Test.Html.Selector as Selector exposing (tag, class, classes, attribute)
+
+
+{-| @ltignore
+-}
+all : Test
+all =
+    Test.concat
+        [ simpleTabs
+        , pillsAndAttributes
+        , horizontalAlignment
+        ]
+
+
+simpleTabs : Test
+simpleTabs =
+    let
+        html =
+            Tab.config (\_ -> ())
+                |> Tab.items
+                    [ Tab.item
+                        { link = Tab.link [] [ text "Tab 1" ]
+                        , pane =
+                            Tab.pane [ Attributes.class "mt-3" ]
+                                [ h4 [] [ text "Tab 1 Heading" ]
+                                , p [] [ text "Contents of tab 1." ]
+                                ]
+                        }
+                    , Tab.item
+                        { link = Tab.link [] [ text "Tab 2" ]
+                        , pane =
+                            Tab.pane [ Attributes.class "mt-3" ]
+                                [ h4 [] [ text "Tab 2 Heading" ]
+                                , p [] [ text "This is something completely different." ]
+                                ]
+                        }
+                    ]
+                |> Tab.view Tab.initialState
+
+        nav =
+            html
+                |> Query.fromHtml
+                |> Query.find [ class "nav" ]
+
+        content =
+            html
+                |> Query.fromHtml
+                |> Query.find [ class "tab-content" ]
+    in
+        describe "Simple tab"
+            [ describe "nav"
+                [ test "Expect 2 nav-items" <|
+                    \() ->
+                        nav
+                            |> Query.findAll [ class "nav-item" ]
+                            |> Query.count (Expect.equal 2)
+                , test "Expect links to have href='#'" <|
+                    \() ->
+                        nav
+                            |> Query.findAll [ tag "a" ]
+                            |> Query.each (Query.has [ attribute "href" "#" ])
+                , test "Expect links to have children" <|
+                    \() ->
+                        nav
+                            |> Query.findAll [ tag "a" ]
+                            |> Query.index 0
+                            |> Query.has [ Selector.text "Tab 1" ]
+                ]
+            , describe "content"
+                [ test "Expect 2 tab-panes" <|
+                    \() ->
+                        content
+                            |> Query.findAll [ class "tab-pane" ]
+                            |> Query.count (Expect.equal 2)
+                , test "Expect 2 mt-3 (custom attributes work)" <|
+                    \() ->
+                        content
+                            |> Query.findAll [ class "mt-3" ]
+                            |> Query.count (Expect.equal 2)
+                , test "Expect pane to have children" <|
+                    \() ->
+                        content
+                            |> Query.findAll [ class "tab-pane" ]
+                            |> Query.index 0
+                            |> Query.find [ tag "h4" ]
+                            |> Query.has [ Selector.text "Tab 1 Heading" ]
+                ]
+            ]
+
+
+pillsAndAttributes =
+    let
+        html =
+            Tab.config (\_ -> ())
+                |> Tab.pills
+                |> Tab.attrs [ Attributes.name "myTabs" ]
+                |> Tab.view Tab.initialState
+    in
+        describe "pills"
+            [ test "Expect nav-pills class" <|
+                \() ->
+                    html
+                        |> Query.fromHtml
+                        |> Query.find [ tag "ul" ]
+                        |> Query.has [ class "nav-pills" ]
+            , test "Expect custom name attribute" <|
+                \() ->
+                    html
+                        |> Query.fromHtml
+                        |> Query.find [ tag "ul" ]
+                        |> Query.has [ attribute "name" "myTabs" ]
+            ]
+
+
+horizontalAlignment =
+    let
+        html alignment =
+            Tab.config (\_ -> ())
+                |> alignment
+                |> Tab.view Tab.initialState
+
+        alignmentTest alignment className =
+            test ("alignment of " ++ className) <|
+                \() ->
+                    html alignment
+                        |> Query.fromHtml
+                        |> Query.find [ class "nav-tabs" ]
+                        |> Query.has [ class className ]
+    in
+        describe "alignment"
+            [ alignmentTest Tab.center "justify-content-center"
+            , alignmentTest Tab.right "justify-content-end"
+            , alignmentTest Tab.justified "nav-justified"
+            , alignmentTest Tab.fill "nav-fill"
+            ]

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -7,6 +7,7 @@ import Bootstrap.ButtonGroupTest as ButtonGroupTest
 import Bootstrap.CardTest as CardTest
 import Bootstrap.DropdownTest as DropdownTest
 import Bootstrap.ListGroupTest as ListGroupTest
+import Bootstrap.TabTest as TabTest
 import Bootstrap.TableTest as TableTest
 import Bootstrap.ProgressTest as ProgressTest
 import Test exposing (..)
@@ -24,6 +25,7 @@ all =
         , CardTest.all
         , DropdownTest.all
         , ListGroupTest.all
+        , TabTest.all
         , TableTest.all
         , ProgressTest.all
         ]


### PR DESCRIPTION
Tests for Tab

Currently only tests the html. Testing the (animation) logic is trickier. We'd need an internal module to expose the type internals to the tests in order to do anything useful on that front.

tracked in #22 