### PR TITLE
Add breadcrumb support

### DIFF
--- a/src/Bootstrap/Breadcrumb.elm
+++ b/src/Bootstrap/Breadcrumb.elm
@@ -1,0 +1,69 @@
+module Bootstrap.Breadcrumb
+    exposing
+        ( container
+        , item
+        , Item
+        )
+
+{-| Indicate the current page's location within a navigational hierarchy that automatically adds separators via CSS.
+
+    Breadcrumb.container
+        [ Breadcrumb.item [] [ a [ href "#home" ] [ text "home" ] ]
+        , Breadcrumb.item [] [ text "page" ]
+        ]
+
+
+# Breadcrumb
+
+@docs Item, item, container
+
+-}
+
+import Html
+import Html.Attributes
+
+
+{-| Opaque type representing an item in the breadcrumb trail.
+-}
+type Item msg
+    = Item (List (Html.Attribute msg)) (List (Html.Html msg))
+
+
+{-| Create a breadcrumb item.
+
+  - `attributes` List of attributes
+  - `children` List of child elements
+
+-}
+item : List (Html.Attribute msg) -> List (Html.Html msg) -> Item msg
+item attributes children =
+    Item attributes children
+
+
+{-| Create a breadcrumb container.
+
+  - `items` List of breadcrumb items
+
+-}
+container : List (Item msg) -> Html.Html msg
+container items =
+    case items of
+        [] ->
+            Html.text ""
+
+        _ ->
+            Html.nav [ Html.Attributes.attribute "aria-label" "breadcrumb", Html.Attributes.attribute "role" "navigation" ]
+                [ Html.ol [ Html.Attributes.class "breadcrumb" ] <| toListItems items ]
+
+
+toListItems : List (Item msg) -> List (Html.Html msg)
+toListItems items =
+    case items of
+        [] ->
+            []
+
+        [ Item attributes children ] ->
+            [ Html.li (attributes ++ [ (Html.Attributes.attribute "aria-current" "page"), Html.Attributes.class "breadcrumb-item active" ]) children ]
+
+        (Item attributes children) :: rest ->
+            [ Html.li (attributes ++ [ Html.Attributes.class "breadcrumb-item" ]) children ] ++ (toListItems rest)

--- a/tests/Bootstrap/BreadcrumbTest.elm
+++ b/tests/Bootstrap/BreadcrumbTest.elm
@@ -1,0 +1,95 @@
+module Bootstrap.BreadcrumbTest exposing (..)
+
+import Bootstrap.Breadcrumb as Breadcrumb
+import Expect
+import Html exposing (div, text)
+import Test exposing (Test, describe, test)
+import Test.Html.Query as Query
+import Test.Html.Selector exposing (attribute, class, tag)
+
+
+testWithoutItems : Test
+testWithoutItems =
+    let
+        html =
+            Breadcrumb.container []
+    in
+        describe "Test without items"
+            [ test "Expect an empty text node only" <|
+                \() ->
+                    html
+                        |> Expect.equal (text "")
+            ]
+
+
+testWithTwoItems : Test
+testWithTwoItems =
+    let
+        html =
+            div []
+                [ Breadcrumb.container
+                    [ Breadcrumb.item [] [ text "home" ]
+                    , Breadcrumb.item [] [ text "page" ]
+                    ]
+                ]
+    in
+        describe "Tests with two items"
+            [ test "Expect the navigation with an aria-label" <|
+                \() ->
+                    html
+                        |> Query.fromHtml
+                        |> Query.find [ tag "nav" ]
+                        |> Query.has [ attribute "aria-label" "breadcrumb" ]
+            , test "Expect the navigation with the role 'navigation'" <|
+                \() ->
+                    html
+                        |> Query.fromHtml
+                        |> Query.find [ tag "nav" ]
+                        |> Query.has [ attribute "role" "navigation" ]
+            , test "Expect the orderen list with the class 'breadcrumb'" <|
+                \() ->
+                    html
+                        |> Query.fromHtml
+                        |> Query.find [ tag "ol" ]
+                        |> Query.has [ class "breadcrumb" ]
+            , test "Expect two list items" <|
+                \() ->
+                    html
+                        |> Query.fromHtml
+                        |> Query.findAll [ tag "li" ]
+                        |> Query.count (Expect.equal 2)
+            , test "Expect list items with class the 'breadcrumb-item'" <|
+                \() ->
+                    html
+                        |> Query.fromHtml
+                        |> Query.findAll [ tag "li" ]
+                        |> Query.each (Query.has [ class "breadcrumb-item" ])
+            , test "Expect first element to contain 'home'" <|
+                \() ->
+                    html
+                        |> Query.fromHtml
+                        |> Query.findAll [ tag "li" ]
+                        |> Query.index 0
+                        |> Query.contains [ text "home" ]
+            , test "Expect second element to contain 'page'" <|
+                \() ->
+                    html
+                        |> Query.fromHtml
+                        |> Query.findAll [ tag "li" ]
+                        |> Query.index 1
+                        |> Query.contains [ text "page" ]
+            , test "Expect first element without an aria-current" <|
+                \() ->
+                    html
+                        |> Query.fromHtml
+                        |> Query.findAll [ tag "li" ]
+                        |> Query.index 0
+                        |> Query.hasNot [ attribute "aria-current" "page" ]
+            , test "Expect second/last element with an aria-current" <|
+                \() ->
+                    html
+                        |> Query.fromHtml
+                        |> Query.findAll [ tag "li" ]
+                        |> Query.index 1
+                        |> Query.has [ attribute "aria-current" "page" ]
+            ]


### PR DESCRIPTION
Hi,
here is a simple breadcrumb support you might want to include into your library.

Some comments:
* I kept it simple, because its a tiny thing after all and if someone e.g. wants to include links, its possible using plain old Html.a.
* I'm not sure about the `container` name.
* I tried to follow the code and documentation style in your project (elm-format messes up my doc, sorry).
* I could not generate the doc on my machine and I'm new to elm, so I guessed how it should look like.