### PR TITLE
Add accordion initialization options

### DIFF
--- a/src/Bootstrap/Accordion.elm
+++ b/src/Bootstrap/Accordion.elm
@@ -18,6 +18,7 @@ module Bootstrap.Accordion
         , appendHeader
         , subscriptions
         , initialState
+        , initialStateWithOptions
         , config
         , State
         , Config
@@ -25,10 +26,11 @@ module Bootstrap.Accordion
         , CardBlock
         , Header
         , Toggle
+        , StateOptions
+        , Visibility(Shown, Hidden)
         )
 
 {-| An accordion is a group of stacked cards where you can toggle the visibility (slide up/down) of each card
-
 
     type alias Model =
         { accordionState = Accordion.state }
@@ -88,17 +90,17 @@ module Bootstrap.Accordion
         Accordion.subscriptions model.accordionState AccordionMsg
 
 
-
 ## Accordion
 @docs view, config, cards, withAnimation,  Config, initialState, State
 
 ## Contents
+
 @docs card, block, listGroup, header, toggle, headerH1, headerH2, headerH3, headerH4, headerH5, headerH6, appendHeader, prependHeader, Card, CardBlock, Header, Toggle
 
 
 ## Animation
-@docs subscriptions
 
+@docs subscriptions
 
 -}
 
@@ -135,11 +137,35 @@ type State
     = State (Dict String CardState)
 
 
+{-| Configuration for the State
+-}
+type alias StateOptions =
+    { id : String
+    , visibility : Visibility
+    }
+
+
 {-| Initial state for the accordion. Typically used from your main `init` function
 -}
 initialState : State
 initialState =
     State Dict.empty
+
+
+{-| An initial state with customized options
+
+    myOptions =
+        [ StateOptions "cardId" Accordion.Shown ]
+
+    init =
+        initialStateWithOptions myOptions
+
+-}
+initialStateWithOptions : List StateOptions -> State
+initialStateWithOptions options =
+    State <|
+        Dict.fromList <|
+            List.map (\option -> ( option.id, CardState option.visibility Nothing )) options
 
 
 type alias CardState =
@@ -148,6 +174,7 @@ type alias CardState =
     }
 
 
+{-| -}
 type Visibility
     = Hidden
     | StartDown
@@ -623,7 +650,7 @@ animationAttributes state config ((Card { id }) as card) =
                 [ style [ ( "height", pixelHeight ) ] ]
 
             Shown ->
-                [ style [ ( "height", pixelHeight ) ] ]
+                []
 
 
 transitionHandler :

--- a/tests/Bootstrap/AccordionTest.elm
+++ b/tests/Bootstrap/AccordionTest.elm
@@ -1,0 +1,84 @@
+module Bootstrap.AccordionTest exposing (..)
+
+import Bootstrap.Accordion as Accordion
+import Bootstrap.Card.Block as Card
+import Html
+import Test exposing (Test, test, describe)
+import Test.Html.Query as Query
+import Test.Html.Selector exposing (text, tag, class, classes, attribute, id, style)
+
+
+type Msg
+    = AccordionMsg Accordion.State
+
+
+oneCardAccordion : Accordion.State -> Html.Html Msg
+oneCardAccordion state =
+    Accordion.config AccordionMsg
+        |> Accordion.withAnimation
+        |> Accordion.cards
+            [ Accordion.card
+                { id = "card1"
+                , options = []
+                , header =
+                    Accordion.header [] <| Accordion.toggle [] [ Html.text "Card 1" ]
+                , blocks =
+                    [ Accordion.block []
+                        [ Card.text [] [ Html.text "Lorem ipsum etc" ] ]
+                    ]
+                }
+            ]
+        |> Accordion.view state
+
+
+accordion : Test
+accordion =
+    let
+        stateDefault =
+            Accordion.initialState
+
+        stateOpen =
+            Accordion.initialStateWithOptions [ Accordion.StateOptions "card1" Accordion.Shown ]
+
+        stateClosed =
+            Accordion.initialStateWithOptions [ Accordion.StateOptions "card1" Accordion.Hidden ]
+
+        htmlDefault =
+            oneCardAccordion stateDefault
+
+        htmlOpen =
+            oneCardAccordion stateOpen
+
+        htmlClosed =
+            oneCardAccordion stateClosed
+    in
+        describe "Accordion"
+            [ test "expect default card to be closed" <|
+                \() ->
+                    htmlDefault
+                        |> Query.fromHtml
+                        |> Query.find [ id "card1" ]
+                        |> Query.has
+                            [ style [ ( "height", "0" ), ( "overflow", "hidden" ) ] ]
+            , test "expect card with option `shown` to be open (no height of 0)" <|
+                \() ->
+                    htmlOpen
+                        |> Query.fromHtml
+                        |> Query.find [ id "card1" ]
+                        |> Query.hasNot
+                            [ style [ ( "height", "0" ) ] ]
+            , test "expect card with option `shown` to be open (no hidden overflow)" <|
+                \() ->
+                    htmlOpen
+                        |> Query.fromHtml
+                        |> Query.find [ id "card1" ]
+                        |> Query.hasNot
+                            [ style [ ( "overflow", "hidden" ) ] ]
+            , test "expect card with option `hidden` to be closed" <|
+                \() ->
+                    htmlClosed
+                        |> Query.fromHtml
+                        |> Query.find [ id "card1" ]
+                        |> Query.has
+                            [ style [ ( "height", "0" ), ( "overflow", "hidden" ) ] ]
+            ]

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -11,7 +11,7 @@
     "dependencies": {
       "elm-community/elm-test": "4.0.0 <= v < 5.0.0",
       "MichaelCombs28/elm-dom": "1.0.0 <= v < 2.0.0",
-      "eeue56/elm-html-test": "3.0.0 <= v < 4.0.0",
+      "eeue56/elm-html-test": "4.0.0 <= v < 5.0.0",
         "elm-lang/animation-frame": "1.0.1 <= v < 2.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",


### PR DESCRIPTION
Here is a simple addition to allow open cards within accordion on startup  (#85, #66) .
* I used carousel as a reference
* I had to raise the elm-html-test version to >4, to be able to test `style`
* Removing the `style` on the `Shown` state does not seem to break anything, but does not mess with unknown hight on startup 
* It does not work with an animated starting state, only with `Shown` and `Hidden`