### PR TITLE
Adapt Navbar module to Bootstrap v4.0.0

### DIFF
--- a/src/Bootstrap/Navbar.elm
+++ b/src/Bootstrap/Navbar.elm
@@ -1095,7 +1095,7 @@ navbarAttributes options =
         , ( "container", options.isContainer )
         ]
     , class <|
-        "navbar-toggleable"
+        "navbar-expand"
             ++ (Maybe.map (\s -> "-" ++ s) (GridInternal.screenSizeOption options.toggleAt)
                     |> Maybe.withDefault ""
                )
@@ -1139,7 +1139,7 @@ linkModifierClass modifier =
     class <|
         case modifier of
             Dark ->
-                "navbar-inverse"
+                "navbar-dark"
 
             Light ->
                 "navbar-light"
@@ -1167,7 +1167,7 @@ backgroundColorOption bgClass =
             class "bg-danger"
 
         Inverse ->
-            class "bg-inverse"
+            class "bg-dark"
 
         Custom color ->
             style [ ( "background-color", toRGBString color ) ]

--- a/src/Bootstrap/Navbar.elm
+++ b/src/Bootstrap/Navbar.elm
@@ -1308,18 +1308,25 @@ renderDropdown state ((Config { options }) as config) (Dropdown { id, toggle, it
                 )
                 options.fix
                 |> Maybe.withDefault False
+
+        isShown =
+            getOrInitDropdownStatus id state /= Closed
     in
         Html.li
             [ classList
                 [ ( "nav-item", True )
                 , ( "dropdown", True )
                 , ( "dropup", needsDropup )
-                , ( "show", getOrInitDropdownStatus id state /= Closed )
+                , ( "show", isShown )
                 ]
             ]
             [ renderDropdownToggle state id config toggle
             , Html.div
-                [ class "dropdown-menu" ]
+                [ classList
+                    [ ( "dropdown-menu", True )
+                    , ( "show", isShown )
+                    ]
+                ]
                 (List.map (\(DropdownItem item) -> item) items)
             ]
 


### PR DESCRIPTION
I adapted some class names to work with Bootstrap v4.0.0.

This was necessary to achieve a dropdown menu in the navbar.

Also I did not add tests, because I didn't find any for `Navbar`.

And thanks for the good work for this package :)