### PR TITLE
Makes instructions clearer

### DIFF
--- a/src/Bootstrap/Accordion.elm
+++ b/src/Bootstrap/Accordion.elm
@@ -394,14 +394,18 @@ headerH6 =
     headerPrivate Html.h6
 
 
-{-| Add elements before the toggle element in a accordion card header
+{-| Add elements before the toggle element in a accordion card header. Order matters if you're using
+both prependHeader and appendHeader. Specifically, it should be toggle |> appendHeader |>
+prependHeader.
 -}
 prependHeader : List (Html.Html msg) -> Header msg -> Header msg
 prependHeader elements (Header header) =
     Header { header | childrenPreToggle = elements ++ header.childrenPreToggle }
 
 
-{-| Add elements after the toggle element in a accordion card header
+{-| Add elements after the toggle element in a accordion card header. Order matters if you're using
+both prependHeader and appendHeader. Specifically, it should be toggle |> appendHeader |>
+prependHeader.
 -}
 appendHeader : List (Html.Html msg) -> Header msg -> Header msg
 appendHeader elements (Header header) =


### PR DESCRIPTION
If you're trying to both prepend and append elements to the toggle
header, the order matters. This PR makes that clear by adding
instructions to both the prependHeader and appendHeader functions.