### PR TITLE
Allows an action on tab select

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,21 @@
 # Elm Bootstrap [![Travis build Status](https://travis-ci.org/rundis/elm-bootstrap.svg?branch=master)]
 
-
+This is a minor (intended to be temporary) change to rundis/elm-bootstrap which allows you to do an
+action on Tab selection instead of just Tab click.
 
 Elm Bootstrap is a comprehensive library package that aims to make it pleasant and reasonably type safe to use [Twitter Bootstrap 4](https://getbootstrap.com/) CSS Framework in Elm applications.
 
-
 Twitter Bootstrap is one of the most popular CSS (with some JS) frameworks for building responsive, mobile first web sites. Version 4 is fully embracing flexbox, which provides much better control and flexibility.
 
-
 ### What's in it for me?
+
 * A reasonably type safe API for using Bootstrap
 * Some boilerplate is being handled for you
 * Interactive elements like Navbar, Dropdowns, Accordion, Modal, Popups, Dismissable Alerts, Tabs and Carousel
 * Horizontally AND vertically center stuff without tearing your hair out
 
-
-
-
 ## Documentation
+
 * User documentation - Check out the [Docs Site](http://elm-bootstrap.info/). If need/prefer https
 you'll need to go [here](https://elm-bootstrap.surge.sh/).
 * API documentation - is up on [Elm Package](http://package.elm-lang.org/packages/rundis/elm-bootstrap/latest).

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,7 +1,7 @@
 {
-    "version": "4.1.0",
-    "summary": "Elm Bootstrap is a comprehensive library for working with Twitter Bootstrap 4",
-    "repository": "https://github.com/rundis/elm-bootstrap.git",
+    "version": "1.0.0",
+    "summary": "This is a minor (intended to be temporary) change to rundis/elm-bootstrap.",
+    "repository": "https://github.com/jasonmfry/elm-bootstrap.git",
     "license": "BSD3",
     "source-directories": [
         "src/"

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.0",
+    "version": "1.0.1",
     "summary": "This is a minor (intended to be temporary) change to rundis/elm-bootstrap.",
     "repository": "https://github.com/jasonmfry/elm-bootstrap.git",
     "license": "BSD3",

--- a/src/Bootstrap/Tab.elm
+++ b/src/Bootstrap/Tab.elm
@@ -367,6 +367,16 @@ view state ((Config { items }) as config) =
                 ]
 
 
+viewWithAction : State -> Config msg -> (String -> msg -> msg) -> Html.Html msg
+viewWithAction state ((Config { items }) as config) action =
+    case getActiveItem state config of
+        Nothing ->
+            view state config
+
+        Just (Item currentItem) ->
+            Html.map (action currentItem.id) <| view state config
+
+
 getActiveItem : State -> Config msg -> Maybe (Item msg)
 getActiveItem (State { activeTab }) (Config { items }) =
     case activeTab of


### PR DESCRIPTION
There was no way to do an action on tab selection, only on tab click.
This was problematic because tabs are selected on pageload, which means
the first tab would be expanded without calling the action if you rely
on tab click. Our specific usecase is to make an API call on tab select
rather than on tab click, and this commit makes that possible.

In order to not break the existing API we created a new function,
`viewWithAction`, instead of modifying `view`.