### PR TITLE
Add Card.customListGroup

### DIFF
--- a/src/Bootstrap/Card.elm
+++ b/src/Bootstrap/Card.elm
@@ -1,12 +1,52 @@
-module Bootstrap.Card exposing
-    ( view, Config
-    , header, headerH1, headerH2, headerH3, headerH4, headerH5, headerH6, Header
-    , Footer, footer
-    , imgTop, imgBottom, ImageTop, ImageBottom
-    , config, align, primary, secondary, success, info, warning, danger, light, dark, outlinePrimary, outlineSecondary, outlineSuccess, outlineInfo, outlineWarning, outlineDanger, outlineLight, outlineDark, textColor, attrs, Option
-    , block, listGroup
-    , group, deck, columns, keyedGroup, keyedDeck, keyedColumns
-    )
+module Bootstrap.Card
+    exposing
+        ( view
+        , Config
+        , header
+        , headerH1
+        , headerH2
+        , headerH3
+        , headerH4
+        , headerH5
+        , headerH6
+        , Header
+        , Footer
+        , footer
+        , imgTop
+        , imgBottom
+        , ImageTop
+        , ImageBottom
+        , config
+        , align
+        , primary
+        , secondary
+        , success
+        , info
+        , warning
+        , danger
+        , light
+        , dark
+        , outlinePrimary
+        , outlineSecondary
+        , outlineSuccess
+        , outlineInfo
+        , outlineWarning
+        , outlineDanger
+        , outlineLight
+        , outlineDark
+        , textColor
+        , attrs
+        , Option
+        , block
+        , listGroup
+        , customListGroup
+        , group
+        , deck
+        , columns
+        , keyedGroup
+        , keyedDeck
+        , keyedColumns
+        )
 
 {-| A card is a flexible and extensible content container. It includes options for headers and footers, a wide variety of content, contextual background colors, and powerful display options.
 
@@ -518,6 +558,21 @@ listGroup items (Config conf) =
             | blocks =
                 conf.blocks
                     ++ [ Internal.listGroup items ]
+        }
+
+
+{-| Use this function if you want to use ListGroup.custom
+-}
+customListGroup :
+    List (ListGroup.CustomItem msg)
+    -> Config msg
+    -> Config msg
+customListGroup items (Config conf) =
+    Config
+        { conf
+            | blocks =
+                conf.blocks
+                    ++ [ Internal.customListGroup items ]
         }
 
 

--- a/src/Bootstrap/Card/Internal.elm
+++ b/src/Bootstrap/Card/Internal.elm
@@ -1,4 +1,4 @@
-module Bootstrap.Card.Internal exposing (BlockItem(..), BlockOption(..), BlockOptions, CardBlock(..), CardOption(..), CardOptions, RoleOption(..), applyBlockModifier, applyModifier, block, blockAttributes, cardAttributes, defaultBlockOptions, defaultOptions, listGroup, renderBlock, renderBlocks)
+module Bootstrap.Card.Internal exposing (BlockItem(..), BlockOption(..), BlockOptions, CardBlock(..), CardOption(..), CardOptions, RoleOption(..), applyBlockModifier, applyModifier, block, blockAttributes, cardAttributes, defaultBlockOptions, defaultOptions, listGroup, customListGroup, renderBlock, renderBlocks)
 
 import Bootstrap.Internal.ListGroup as ListGroup
 import Bootstrap.Internal.Role as Role
@@ -94,35 +94,43 @@ listGroup items =
         |> ListGroup
 
 
+customListGroup : List (ListGroup.CustomItem msg) -> CardBlock msg
+customListGroup items =
+    Html.ul
+        [ class "list-group list-group-flush" ]
+        (List.map ListGroup.renderCustomItem items)
+        |> ListGroup
+
+
 blockAttributes : List (BlockOption msg) -> List (Html.Attribute msg)
 blockAttributes modifiers =
     let
         options =
             List.foldl applyBlockModifier defaultBlockOptions modifiers
     in
-    [ class "card-body" ]
-        ++ (case options.aligned of
-                Just align ->
-                    [ Text.textAlignClass align ]
+        [ class "card-body" ]
+            ++ (case options.aligned of
+                    Just align ->
+                        [ Text.textAlignClass align ]
 
-                Nothing ->
-                    []
-           )
-        ++ (case options.coloring of
-                Just role ->
-                    [ Role.toClass "bg" role ]
+                    Nothing ->
+                        []
+               )
+            ++ (case options.coloring of
+                    Just role ->
+                        [ Role.toClass "bg" role ]
 
-                Nothing ->
-                    []
-           )
-        ++ (case options.textColoring of
-                Just color ->
-                    [ Text.textColorClass color ]
+                    Nothing ->
+                        []
+               )
+            ++ (case options.textColoring of
+                    Just color ->
+                        [ Text.textColorClass color ]
 
-                Nothing ->
-                    []
-           )
-        ++ options.attributes
+                    Nothing ->
+                        []
+               )
+            ++ options.attributes
 
 
 defaultBlockOptions : BlockOptions msg
@@ -156,32 +164,32 @@ cardAttributes modifiers =
         options =
             List.foldl applyModifier defaultOptions modifiers
     in
-    [ class "card" ]
-        ++ (case options.coloring of
-                Just (Roled role) ->
-                    [ Role.toClass "bg" role ]
+        [ class "card" ]
+            ++ (case options.coloring of
+                    Just (Roled role) ->
+                        [ Role.toClass "bg" role ]
 
-                Just (Outlined role) ->
-                    [ Role.toClass "border" role ]
+                    Just (Outlined role) ->
+                        [ Role.toClass "border" role ]
 
-                Nothing ->
-                    []
-           )
-        ++ (case options.textColoring of
-                Just color ->
-                    [ Text.textColorClass color ]
+                    Nothing ->
+                        []
+               )
+            ++ (case options.textColoring of
+                    Just color ->
+                        [ Text.textColorClass color ]
 
-                Nothing ->
-                    []
-           )
-        ++ (case options.aligned of
-                Just align ->
-                    [ Text.textAlignClass align ]
+                    Nothing ->
+                        []
+               )
+            ++ (case options.aligned of
+                    Just align ->
+                        [ Text.textAlignClass align ]
 
-                Nothing ->
-                    []
-           )
-        ++ options.attributes
+                    Nothing ->
+                        []
+               )
+            ++ options.attributes
 
 
 defaultOptions : CardOptions msg


### PR DESCRIPTION
Doesn't look like there's currently a way to do full-width list groups with buttons, links, etc inside of a card as shown [here](https://getbootstrap.com/docs/4.1/components/card/#list-groups). If I missed something and it's possible without changes, feel free to close this PR. 

My usecase is something like
```
viewFoos foos =
    Card.config [ Card.outlineInfo, Card.align Text.alignXsCenter ]
        |> Card.headerH3 []
            [ text "Select a foo" ]
        |> Card.customListGroup
            (List.map viewFoo foos)
        |> Card.view


viewFoo : String -> ListGroup.CustomItem Msg
viewFoo foo =
    ListGroup.button [ ListGroup.primary ] [ text foo ]

```