### PR TITLE
Support form-control-plaintext

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "license": "UNLICENSED",
+  "name": "elm",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "elm": "^0.19",
+    "elm-format": "0.8.1",
+    "elm-test": "0.19.0-beta12"
+  },
+  "devDependencies": {
+  },
+  "resolutions": {
+  },
+  "scripts": {
+  }
+}

--- a/src/Bootstrap/Form/Input.elm
+++ b/src/Bootstrap/Form/Input.elm
@@ -61,6 +61,14 @@ type Option msg
     | Attrs (List (Html.Attribute msg))
 
 
+{-| Type representing legal read only settings for the read-only attribute
+-}
+type ReadonlySetting
+    = Yes
+    | No
+    | Plain
+
+
 type InputType
     = Text
     | Password

--- a/src/Bootstrap/Form/Input.elm
+++ b/src/Bootstrap/Form/Input.elm
@@ -1,6 +1,7 @@
 module Bootstrap.Form.Input exposing
     ( text, password, datetimeLocal, date, month, time, week, number, email, url, search, tel, color
-    , id, small, large, value, disabled, readonly, onInput, placeholder, attrs, Option
+    , id, small, large, value, disabled, onInput, placeholder, attrs, Option
+    , ReadonlySetting(..), readonly
     , success, danger
     )
 
@@ -14,7 +15,14 @@ module Bootstrap.Form.Input exposing
 
 # Options
 
-@docs id, small, large, value, disabled, readonly, onInput, placeholder, attrs, Option
+@docs id, small, large, value, disabled, onInput, placeholder, attrs, Option
+
+
+# ReadonlySetting
+
+Refers to whether a form element is read only (Yes) or not (No) or read only plain test (Plain)
+
+@docs ReadonlySetting, readonly
 
 
 # Validation
@@ -49,7 +57,7 @@ type Option msg
     | OnInput (String -> msg)
     | Validation FormInternal.Validation
     | Placeholder String
-    | Readonly Bool
+    | Readonly ReadonlySetting
     | Attrs (List (Html.Attribute msg))
 
 
@@ -78,7 +86,7 @@ type alias Options msg =
     , placeholder : Maybe String
     , onInput : Maybe (String -> msg)
     , validation : Maybe FormInternal.Validation
-    , readonly : Bool
+    , readonly : ReadonlySetting
     , attributes : List (Html.Attribute msg)
     }
 
@@ -256,7 +264,7 @@ disabled disabled_ =
 
 {-| Shorthand for setting the readonly attribute of an input
 -}
-readonly : Bool -> Option msg
+readonly : ReadonlySetting -> Option msg
 readonly readonly_ =
     Readonly readonly_
 
@@ -281,9 +289,9 @@ toAttributes modifiers =
         options =
             List.foldl applyModifier defaultOptions modifiers
     in
-    [ Attributes.class "form-control"
+    [ Attributes.class (formControl options)
     , Attributes.disabled options.disabled
-    , Attributes.readonly options.readonly
+    , readOnly options
     , typeAttribute options.tipe
     ]
         ++ ([ Maybe.map Attributes.id options.id
@@ -298,6 +306,27 @@ toAttributes modifiers =
         ++ options.attributes
 
 
+formControl : Options msg -> String
+formControl options =
+    case options.readonly of
+        Plain ->
+            "form-control-plaintext"
+
+        _ ->
+            "form-control"
+
+
+readOnly : Options msg -> Html.Attribute msg
+readOnly options =
+    Attributes.readonly <|
+        case options.readonly of
+            No ->
+                False
+
+            _ ->
+                True
+
+
 defaultOptions : Options msg
 defaultOptions =
     { tipe = Text
@@ -308,7 +337,7 @@ defaultOptions =
     , placeholder = Nothing
     , onInput = Nothing
     , validation = Nothing
-    , readonly = False
+    , readonly = No
     , attributes = []
     }
 

--- a/src/Bootstrap/Modal.elm
+++ b/src/Bootstrap/Modal.elm
@@ -6,6 +6,7 @@ module Bootstrap.Modal exposing
     , body, Body
     , footer, Footer
     , withAnimation, subscriptions, hiddenAnimated
+    , hideBorder, transparent
     )
 
 {-| Modals are streamlined, but flexible dialog prompts. They support a number of use cases from user notifications to completely custom content and feature a handful of helpful subcomponents, sizes, and more.
@@ -127,7 +128,6 @@ is a few more things you must wire-up and keep in mind.
             AnimateModal visibility ->
                 { state | modalVisibility = visibility }
 
-
     -- Animations for modal doesn't work without a subscription.
     -- DON´T forget this !
     subscriptions : Model -> Sub msg
@@ -234,6 +234,8 @@ type alias Options =
     { modalSize : Maybe ScreenSize
     , hideOnBackdropClick : Bool
     , centered : Bool
+    , hideBorder : Bool
+    , transparent : Bool
     }
 
 
@@ -282,6 +284,16 @@ hideOnBackdropClick hide (Config ({ options } as conf)) =
     Config { conf | options = { options | hideOnBackdropClick = hide } }
 
 
+hideBorder : Bool -> Config msg -> Config msg
+hideBorder hide (Config ({ options } as conf)) =
+    Config { conf | options = { options | hideBorder = hide } }
+
+
+transparent : Bool -> Config msg -> Config msg
+transparent hide (Config ({ options } as conf)) =
+    Config { conf | options = { options | transparent = hide } }
+
+
 {-| Configure the modal to support fade-in/out animations. You'll need to provide
 a message to handle animation.
 -}
@@ -318,7 +330,20 @@ view visibility (Config conf) =
                        )
                 )
                 [ Html.div
-                    [ Attr.class "modal-content" ]
+                    ([ Attr.class "modal-content" ]
+                        ++ (if conf.options.hideBorder then
+                                [ Attr.style "border" "none" ]
+
+                            else
+                                []
+                           )
+                        ++ (if conf.options.transparent then
+                                [ Attr.style "background-color" "#fff0" ]
+
+                            else
+                                []
+                           )
+                    )
                     (List.filterMap
                         identity
                         [ renderHeader conf
@@ -407,6 +432,8 @@ config closeMsg =
             { modalSize = Nothing
             , hideOnBackdropClick = True
             , centered = True
+            , hideBorder = False
+            , transparent = False
             }
         , header = Nothing
         , body = Nothing


### PR DESCRIPTION
The current option for readonly on an input type prevents the use of Bootstrap's plaintext option.

https://getbootstrap.com/docs/4.0/components/forms/#readonly-plain-text

Please consider.