### PR TITLE
Allow the user to specify that navbar items should be aligned right

### DIFF
--- a/src/Bootstrap/Navbar.elm
+++ b/src/Bootstrap/Navbar.elm
@@ -7,6 +7,7 @@ module Bootstrap.Navbar exposing
     , customItems, textItem, formItem, customItem, CustomItem
     , initialState, State
     , subscriptions
+    , withItemsRight
     )
 
 {-| The navbar is a wrapper that positions branding, navigation, and other elements in a concise header.
@@ -152,6 +153,7 @@ type DropdownStatus
   - `brand` Optional [`brand`](#brand) element (typically a logo)
   - `items` List of menu items that the user can select from
   - `customItems` List of custom (inline) items that you may place to the right of the std. navigation items
+  - `itemsLeft` Whether navbar items should be left or right aligned.
 
 -}
 type Config msg
@@ -165,6 +167,7 @@ type alias ConfigRec msg =
     , brand : Maybe (Brand msg)
     , items : List (Item msg)
     , customItems : List (CustomItem msg)
+    , itemsOnLeft : Bool
     }
 
 
@@ -382,6 +385,7 @@ config toMsg =
             , toggleAt = XS
             , attributes = []
             }
+        , itemsOnLeft = True
         }
 
 
@@ -450,6 +454,13 @@ view state ((Config configRec) as conf) =
 withAnimation : Config msg -> Config msg
 withAnimation config_ =
     updateConfig (\conf -> { conf | withAnimation = True }) config_
+
+
+{-| Align navbar items on the right instead of on the left
+-}
+withItemsRight : Config msg -> Config msg
+withItemsRight config_ =
+    updateConfig (\conf -> { conf | itemsOnLeft = False }) config_
 
 
 {-| Option to fix the menu to the top of the viewport
@@ -1025,7 +1036,13 @@ renderNav :
     -> Html.Html msg
 renderNav state configRec navItems =
     Html.ul
-        [ class "navbar-nav mr-auto" ]
+        [ class "navbar-nav"
+        , if configRec.itemsOnLeft then
+            class "mr-auto"
+
+          else
+            class "ml-auto"
+        ]
         (List.map
             (\item ->
                 case item of


### PR DESCRIPTION
This is a potential fix for #48. I don't know if that's exactly what everyone is asking for, but it's certainly what I'd like. However, I have no idea if it somehow breaks the way that `customItems` work or something.

The idea is to add `withItemsRight`, which allows the user to specify that navbar items should be right aligned instead of left aligned.