### PR TITLE
Don't autohide slide captions on small screens

### DIFF
--- a/src/Bootstrap/Carousel/SlideInternal.elm
+++ b/src/Bootstrap/Carousel/SlideInternal.elm
@@ -41,7 +41,7 @@ view (Config { attributes, content, caption }) =
                     text ""
 
                 Just rec ->
-                    div (rec.attributes ++ [ class "carousel-caption d-none d-md-block" ]) rec.children
+                    div (rec.attributes ++ [ class "carousel-caption" ]) rec.children
     in
     div (attributes ++ [ class "carousel-item" ]) <|
         case content of


### PR DESCRIPTION
IMO this should be up to the developer. But you probably made it this way for a reason, so up to you ;)