### PR TITLE
Correct typo in `ListGroup` documentation

### DIFF
--- a/src/Bootstrap/ListGroup.elm
+++ b/src/Bootstrap/ListGroup.elm
@@ -87,12 +87,12 @@ li options children =
 
     ListGroup.custom
         [ ListGroup.button
-            [ ListGroup.attr <| onClick "MyItem1Msg"
+            [ ListGroup.attrs <| onClick "MyItem1Msg"
             , ListGroup.info
             ]
             [ text "List item 1" ]
         , ListGroup.button
-            [ ListGroup.attr <| onClick "MyItem2Msg"
+            [ ListGroup.attrs <| onClick "MyItem2Msg"
             , ListGroup.warning
             ]
             [ text "List item 2" ]


### PR DESCRIPTION
`ListGroup.attrs` is the correct name of the function