### PR TITLE
Remove class `btn-group` from horizontal ButtonGroup

### DIFF
--- a/src/Bootstrap/ButtonGroup.elm
+++ b/src/Bootstrap/ButtonGroup.elm
@@ -277,7 +277,7 @@ groupAttributes toggle modifiers =
     in
     [ attribute "role" "group"
     , classList
-        [ ( "btn-group", True )
+        [ ( "btn-group", not options.vertical )
         , ( "btn-group-toggle", toggle )
         , ( "btn-group-vertical", options.vertical )
         ]


### PR DESCRIPTION
Fixes #164

At the moment the vertical ButtonGroup looks like this:
![Bildschirmfoto 2019-09-03 um 15 04 34](https://user-images.githubusercontent.com/42995819/64178729-4e763f80-ce62-11e9-98b8-f090adb9afcd.png)

With the changes of this PR it will look like this:
![Bildschirmfoto 2019-09-03 um 15 04 58](https://user-images.githubusercontent.com/42995819/64178737-5209c680-ce62-11e9-80aa-1aaf05627786.png)
