### PR TITLE
Expose Form.Range component

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -23,6 +23,7 @@
         "Bootstrap.Form.Input",
         "Bootstrap.Form.InputGroup",
         "Bootstrap.Form.Radio",
+        "Bootstrap.Form.Range",
         "Bootstrap.Form.Select",
         "Bootstrap.Form.Textarea",
         "Bootstrap.General.HAlign",

--- a/src/Bootstrap/Form/Range.elm
+++ b/src/Bootstrap/Form/Range.elm
@@ -17,7 +17,6 @@ module Bootstrap.Form.Range exposing
 
 -}
 
-import Bootstrap.Form.FormInternal as FormInternal
 import Html
 import Html.Attributes as Attributes
 import Html.Events as Events
@@ -60,7 +59,7 @@ type alias Options msg =
         [ Range.id "myRange"
         , Range.min "-10"
         , Range.max "10"
-        , Radio.onInput MyRangeMsg
+        , Range.onInput MyRangeMsg
         ]
 
 -}


### PR DESCRIPTION
A quick fix for issue #169 
* Form.Range added to exposed modules in elm.json
* Copy-paste error corrected in commented example of Range component usage (Radio -> Range)
* Unused import removed (FormInternal)