### PR TITLE
Fix Form.Checkbox.indeterminate

### DIFF
--- a/src/Bootstrap/Form/Checkbox.elm
+++ b/src/Bootstrap/Form/Checkbox.elm
@@ -21,6 +21,7 @@ import Bootstrap.Form.FormInternal as FormInternal
 import Html
 import Html.Attributes as Attributes
 import Html.Events as Events
+import Json.Encode
 
 
 {-| Opaque composable type representing a Checkbox.
@@ -340,4 +341,4 @@ stateAttribute state =
             Attributes.checked False
 
         Indeterminate ->
-            Attributes.attribute "indeterminate" "true"
+            Attributes.property "indeterminate" <| Json.Encode.bool True


### PR DESCRIPTION
Indeterminate is handled as a DOM property not as an attribute. I'm not sure if this covers the case where we need to set it back to false when going to the checked or unchecked state, but in testing it seem to be an issue.